### PR TITLE
Display tags in post header

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -95,6 +95,9 @@
 								</time>
 								<span class="display-print">by {{ .Params.author | default .Site.Params.author }}</span>
 								{{ range $idx, $cat := .Params.categories }}{{ if gt $idx 0 }}, {{ end }}{{ if eq $idx 0 }} in {{ end }}<a href="{{ "categories/" | absURL }}/{{ . | urlize }}" class="no-underline category {{ cond $hdr "near-white dim" "black hover-gray" }}">{{ . | title }}</a>{{ end }}
+								<div>
+									{{ range $idx, $tag := .Params.tags }}{{ if gt $idx 0 }}, {{ end }}{{ if eq $idx 0 }}Tags: {{ end }}<a href="{{ "tags/" | absURL }}/{{ . | urlize }}" class="no-underline category {{ cond $hdr "near-white dim" "black hover-gray" }}">{{ . | title }}</a>{{ end }}
+								</div>
 								<span class="display-print">at {{ .Permalink }}</span>
 							{{ end }}
 						{{ else }}


### PR DESCRIPTION
Currently, tags unlike categories, aren't displayed in post header.
![pr-1](https://user-images.githubusercontent.com/2694559/49858278-685f8600-fdec-11e8-9dad-1dcc1360e04a.png)

After this PR:
![pr-2](https://user-images.githubusercontent.com/2694559/49858367-a066c900-fdec-11e8-9b15-983efebc2534.png)
