### PR TITLE
Specify theme in exampleSite config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,5 +1,6 @@
 # Site settings
 baseurl = "https://example.com/"
+theme = "story"
 title = "Hugo Story Theme"
 paginate = 5
 buildFuture = true


### PR DESCRIPTION
At present:
```
themes/story/exampleSite$ hugo serve -D --themesDir ../..
Total in 53 ms
Error: Error building site: "/home/rootkea/Documents/hacking/hugo/rootkea.gitlab.io/themes/story/exampleSite/content/math.md:19:30": failed to extract shortcode: template for shortcode "math" not found
themes/story/exampleSite$
```