### PR TITLE
Added csp policies to <head> tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src https://use.fontawesome.com https://fonts.gstatic.com; img-src 'self'; object-src 'none'; script-src https://cdn.jsdelivr.net 'self' https://cdnjs.cloudflare.com; style-src 'self' https://use.fontawesome.com https://fonts.googleapis.com https://cdn.jsdelivr.net 'unsafe-inline'; frame-ancestors 'none'">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; font-src https://use.fontawesome.com fonts.gstatic.com; img-src 'self'; object-src 'self'; script-src 'unsafe-inline' https://cdn.jsdelivr.net 'self' https://cdnjs.cloudflare.com; style-src 'self' https://use.fontawesome.com https://fonts.googleapis.com https://cdn.jsdelivr.net 'unsafe-inline'; frame-ancestors 'none'">
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src https://use.fontawesome.com https://fonts.gstatic.com; img-src 'self'; object-src 'none'; script-src https://cdn.jsdelivr.net 'self' https://cdnjs.cloudflare.com; style-src 'self' https://use.fontawesome.com https://fonts.googleapis.com https://cdn.jsdelivr.net 'unsafe-inline'; frame-ancestors 'none'">
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>


### PR DESCRIPTION
While using this theme on my own site, I went to the [Mozilla Observatory](https://observatory.mozilla.org) and realised that I require a Content Security Policy for better security. I, of course, added it to my nginx config, but I realised it might be better for a lot of people for the theme to have it in the <head> tag by default for increased default security. This is a pull request to add the same.

An additional note. I've added an `unsafe-inline` attribute to the `script-src` part of the header. It would be better if all such inline css references were to be replaced in the theme. I'm hardly a web designer, but I'll try to see what I can do. Perhaps I'll start a new issue for it. :)