### PR TITLE
Fix htmlEscaped chars in json output for lunr

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,5 +1,5 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range where .Site.Pages ".Params.skip" "ne" "true" -}}
-{{- $.Scratch.Add "index" (dict "uri" .Permalink "title" (cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify)) "categories" .Params.categories "keywords" .Params.keywords "content" .Summary) -}}
+{{- $.Scratch.Add "index" (dict "uri" .Permalink "title" (cond (eq .Site.Params.titlecase true) (.Title | title | markdownify | htmlUnescape) (.Title | markdownify | htmlUnescape)) "categories" .Params.categories "keywords" .Params.keywords "content"  (.Summary | plainify | htmlUnescape )) -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
Both .Title and .Summary output modified with `plainify | htmlUnescape`
to remove escaped chars.

See full bug report at #71