### PR TITLE
Add support for using a prebuild lunr index with fallback

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+set -x
+read -p 'Enter a destination directory: ' dest
+hugo -c exampleSite/content --config exampleSite/config.toml -d $dest
+
+cat $dest/index.json | node prebuild-index.js > $dest/prebuilt.json

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -9,7 +9,7 @@
 </article>
 
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.2.1/lunr.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.5/lunr.min.js"></script>
     <script type="text/javascript">
     var lunrIndex, $results, pagesIndex;
     function getQueryVariable(variable) {
@@ -27,30 +27,42 @@
 
     var searchTerm = getQueryVariable('query');
 
-    // Initialize lunrjs using our generated index file
+    // Init lunr with load prebuilt index or build one
     function initLunr() {
-        // First retrieve the index file
-			 $.getJSON("{{ "index.json" | absURL }}")
-            .done(function(index) {
-                pagesIndex = index;
-                // console.log("index:", pagesIndex);
-                lunrIndex = lunr(function() {
-                    this.field("title", { boost: 10 });
-                    this.field("categories", { boost: 5 });
-                    this.field("keywords");
-                    this.field("content");
-                    this.field("uri");
-                    this.ref("uri");
-
-                    pagesIndex.forEach(function (page) {
-                        this.add(page)
-                    }, this)
-                });
+       // try to get prebuilt index file
+       $.getJSON("http://story.test/prebuilt.json")
+            .done(function(data) {
+                lunrIndex = lunr.Index.load(data);
             })
             .fail(function(jqxhr, textStatus, error) {
-                var err = textStatus + ", " + error;
-                console.error("Error fetching Hugo search index JSON file:", err);
-            });
+                var status = jqxhr.status
+                if (status == 404) {
+                  // fall back getting json objects and build index
+                  $.getJSON("http://story.test/index.json")
+                        .done(function(index) {
+                  
+                            lunrIndex = lunr(function() {
+                                this.field("title", { boost: 10 });
+                                this.field("categories", { boost: 5 });
+                                this.field("keywords");
+                                this.field("content");
+                                this.field("uri");
+                                this.ref("uri_title");
+                  
+                                index.forEach(function (page) {
+                                    this.add(page)
+                                }, this)
+                            });
+                        })
+                        .fail(function(jqxhr, textStatus, error) {
+                            var err = textStatus + ", " + error;
+                            console.error("Error fetching Hugo search index JSON file:", err);
+                        });
+                } else {
+                  var err = textStatus + ", " + error;
+                  console.error("Error fetching Hugo prebuilt search index JSON file:", err);     
+                }
+            })
     }
 
     // Nothing crazy here, just hook up a listener on the input field
@@ -78,11 +90,7 @@
      * @return {Array}  results
      */
     function search(query) {
-        return lunrIndex.search(query).map(function(result) {
-                return pagesIndex.filter(function(page) {
-                    return page.uri === result.ref;
-                })[0];
-            });
+         return lunrIndex.search(query)
     }
 
     /**
@@ -98,10 +106,13 @@
         // Only show the first results
         results.slice(0, 20).forEach(function(result) {
             var $result = $("<li>");
-                $result.append($('<a>', {
+            var $parts = result.ref.split("?", 2);
+            var $title = "";
+            ($parts.length == 2) ? $title = $parts[1] : $title = $parts[0];
+            $result.append($('<a>', {
                 class: 'no-underline dim link',
-                href: result.uri,
-                text: result.title
+                href: $parts[0],
+                text: $title
             }));
             $results.append($result);
         });

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,5 +1,6 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range where .Site.Pages ".Params.skip" "ne" "true" -}}
-{{- $.Scratch.Add "index" (dict "uri" .Permalink "title" (cond (eq .Site.Params.titlecase true) (.Title | title | markdownify | htmlUnescape) (.Title | markdownify | htmlUnescape)) "categories" .Params.categories "keywords" .Params.keywords "content"  (.Summary | plainify | htmlUnescape )) -}}
+{{- $.Scratch.Set "uri_title" (printf "%s?%s" .Permalink (cond (eq .Site.Params.titlecase true) (.Title | title | markdownify | htmlUnescape) (.Title | markdownify | htmlUnescape))) -}}
+{{- $.Scratch.Add "index" (dict "uri_title" ($.Scratch.Get "uri_title") "uri" .Permalink "title" (cond (eq .Site.Params.titlecase true) (.Title | title | markdownify | htmlUnescape) (.Title | markdownify | htmlUnescape)) "categories" .Params.categories "keywords" .Params.keywords "content"  (.Summary | plainify | htmlUnescape )) -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}

--- a/prebuild-index.js
+++ b/prebuild-index.js
@@ -1,0 +1,30 @@
+var lunr = require('lunr'),
+    stdin = process.stdin,
+    stdout = process.stdout,
+    buffer = []
+
+stdin.resume()
+stdin.setEncoding('utf8')
+
+stdin.on('data', function (data) {
+  buffer.push(data)
+})
+
+stdin.on('end', function () {
+  var documents = JSON.parse(buffer.join(''))
+
+  var idx = lunr(function () {
+		this.field("title", { boost: 10 });
+		this.field("categories", { boost: 5 });
+		this.field("keywords");
+		this.field("content");
+		this.field("uri");
+		this.ref("uri_title");
+
+    documents.forEach(function (doc) {
+      this.add(doc)
+    }, this)
+  })
+
+  stdout.write(JSON.stringify(idx))
+})


### PR DESCRIPTION
Search.html now looks for a prebuilt.json file to load, and if a 404 is returned falls back to loading index.json and building an index.

Overall, using a prebuilt index on the example site was approx 2.7x faster than building in the browser, even accounting for the larger file size. Details:

| index.json | Size | Time |
|-----------:|------|------|
| network | 9.2k | 0.185ms |
| build | | 17.53ms |
| total | | 17.715ms |

| prebuilt.json | Size | Time |
|--------------:|------|------|
| network | 70k | 0.245ms |
| build | | 6.259ms |
| total | | 6.504ms |


To receive both URI and title in search results, modified index.json to include a joined field used as lunr ref, so pageIndex no longer needs to be a global page index holding all of the JSON just to retrieve title on search results. This was required as that data was no longer available with prebuild index, but overall should be a gain as well.

Updates the version of lunr that is loaded to match the prebuild index version included from node.js. Lunr gives a warning if there is a mismatch, but it still works.

Also included a shell script which builds hugo to and then prebuilds lunr index file. Note: This requires node and lunr module installed locally, and the package.json file is NOT included.