### PR TITLE
Fix: Opengraph metadata key is property not name

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,12 +7,12 @@
 {{ end }}
 
 {{ define "social" }}
-		<meta name="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta name="og:type" content="article" />
-		<meta name="og:image" content="{{ default "img/default-header-img.jpg" .Params.image | absURL }}" />
-		<meta name="og:description" content="{{ .Description | markdownify }}" />
-		<meta name="og:url" content="{{ .Permalink }}" />
-		<meta name="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta property="og:type" content="article" />
+		<meta property="og:image" content="{{ default "img/default-header-img.jpg" .Params.image | absURL }}" />
+		<meta property="og:description" content="{{ .Description | markdownify }}" />
+		<meta property="og:url" content="{{ .Permalink }}" />
+		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
 {{ end }}

--- a/layouts/slides/single.html
+++ b/layouts/slides/single.html
@@ -80,12 +80,12 @@
 {{ end }}
 
 {{ define "social" }}
-		<meta name="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta name="og:type" content="article" />
-		<meta name="og:image" content="{{ default .Params.image .Params.thumbnail | absURL }}" />
-		<meta name="og:description" content="{{ .Description | markdownify }}" />
-		<meta name="og:url" content="{{ .Permalink }}" />
-		<meta name="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta property="og:type" content="article" />
+		<meta property="og:image" content="{{ default .Params.image .Params.thumbnail | absURL }}" />
+		<meta property="og:description" content="{{ .Description | markdownify }}" />
+		<meta property="og:url" content="{{ .Permalink }}" />
+		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
 {{ end }}

--- a/layouts/talks/single.html
+++ b/layouts/talks/single.html
@@ -18,12 +18,12 @@
 {{ end }}
 
 {{ define "social" }}
-		<meta name="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta name="og:type" content="article" />
-		<meta name="og:image" content="{{ default (default "img/default-header-img.jpg" .Params.image) .Params.thumbnail | absURL }}" />
-		<meta name="og:description" content="{{ .Description | markdownify }}" />
-		<meta name="og:url" content="{{ .Permalink }}" />
-		<meta name="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta property="og:type" content="article" />
+		<meta property="og:image" content="{{ default (default "img/default-header-img.jpg" .Params.image) .Params.thumbnail | absURL }}" />
+		<meta property="og:description" content="{{ .Description | markdownify }}" />
+		<meta property="og:url" content="{{ .Permalink }}" />
+		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
 {{ end }}


### PR DESCRIPTION
Opengraph prescribes, that the key attribute is "property" not "name". This PR fixes that.