### PR TITLE
use global hugo function,and .URL deprecated

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -71,10 +71,10 @@
 					</a>
 					<div class="fr h2 pv2 tr">
 						{{- range .Site.Menus.main }}
-						<a class="link f5 ml2 dim near-white" href="{{ .RelPermalink }}">{{ .Name }}</a>
+						<a class="link f5 ml2 dim near-white" href="{{ $.RelPermalink }}">{{ .Name }}</a>
 						{{- end }}
 						{{- range .Site.Menus.social }}
-						<a class="link f5 ml2 dim near-white" href="{{ .RelPermalink }}"><i class="{{ .Title }}"></i></a>
+						<a class="link f5 ml2 dim near-white" href="{{ $.RelPermalink }}"><i class="{{ .Title }}"></i></a>
 						{{- end }}
 						<a class="link f5 ml2 dim near-white fas fa-rss-square" href="{{ "index.xml" | absURL }}" title="RSS Feed"></a>
 						<a class="link f5 ml2 dim near-white fas fa-search" href="{{ "search/" | absURL }}" role="search" title="Search"></a>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
 		<link rel="shortcut icon" type="image/png" href="{{ "apple-touch-icon-precomposed.png" | absURL }}">
 		{{ with .Description }}<meta name="description" content="{{. | markdownify }}">{{ end }}
 		{{ with .Keywords }}<meta name="keywords" content="{{.}}">{{ end }}
-		{{ .Hugo.Generator }}
+		{{ hugo.Generator }}
 
 		{{ block "social" . }}
 		{{ end }}
@@ -71,10 +71,10 @@
 					</a>
 					<div class="fr h2 pv2 tr">
 						{{- range .Site.Menus.main }}
-						<a class="link f5 ml2 dim near-white" href="{{ .URL }}">{{ .Name }}</a>
+						<a class="link f5 ml2 dim near-white" href="{{ .RelPermalink }}">{{ .Name }}</a>
 						{{- end }}
 						{{- range .Site.Menus.social }}
-						<a class="link f5 ml2 dim near-white" href="{{ .URL }}"><i class="{{ .Title }}"></i></a>
+						<a class="link f5 ml2 dim near-white" href="{{ .RelPermalink }}"><i class="{{ .Title }}"></i></a>
 						{{- end }}
 						<a class="link f5 ml2 dim near-white fas fa-rss-square" href="{{ "index.xml" | absURL }}" title="RSS Feed"></a>
 						<a class="link f5 ml2 dim near-white fas fa-search" href="{{ "search/" | absURL }}" role="search" title="Search"></a>


### PR DESCRIPTION
starting with v 0.55

`WARN Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.`

you already had `.Permalink` rightly set on `baseof.html`, so it didn't pick `.URL` from the same file, and thus spitting out the `WARNING .URL will be deprecated` too 

:) that's funny

