### PR TITLE
Add feature flag for search

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -77,7 +77,9 @@
 						<a class="link f5 ml2 dim near-white" href="{{ .URL }}"><i class="{{ .Title }}"></i></a>
 						{{- end }}
 						<a class="link f5 ml2 dim near-white fas fa-rss-square" href="{{ "index.xml" | absURL }}" title="RSS Feed"></a>
+						{{- if (in .Site.Params.classes "feature-search") }}
 						<a class="link f5 ml2 dim near-white fas fa-search" href="{{ "search/" | absURL }}" role="search" title="Search"></a>
+						{{- end}}
 					</div>
 				</nav>
 


### PR DESCRIPTION
Adds a check for this in the `baseof.html` template. If there's no `feature-search`, then the magnifying glass link to the search page isn't displayed at all.