### PR TITLE
Get fonts from params, if configured

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,7 +26,10 @@
 		<link rel="stylesheet" href="{{ "css/descartes.css" | absURL }}" />
 		{{ end }}
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
-		<link href="https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700,700i|Quattrocento:400,700|Spectral:400,400i,700,700i&amp;subset=latin-ext" rel="stylesheet">
+		{{- with .Site.Params.fonts }}
+		{{- $fonts := print (default "Quattrocento Sans" .sansserif.family) ":" (default "400,400i,700,700i" .sansserif.weights) "|" (default "Spectral" .serif.family) ":" (default "400,400i,700,700i" .serif.weights) }}
+		<link href="https://fonts.googleapis.com/css?family={{ $fonts }}&amp;subset=latin-ext" rel="stylesheet">
+		{{- end }}
 		{{ end }}
 
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,6 +18,12 @@
 		{{ block "layout" . }}
 		<link rel="stylesheet" href="{{ "css/tachyons.min.css" | absURL }}" />
 		{{- if .Site.Params.less -}}
+		{{- with .Site.Params.fonts }}
+		<style type="text/less">
+			@config-font-sans: '{{ print (default "Quattrocento Sans" .sansserif.family) }}';
+			@config-font-serif: '{{ print (default "Spectral" .serif.family) }}';
+		</style>
+		{{- end }}
 		<link rel="stylesheet/less" type="text/css" href="{{ "css/story.less" | absURL }}" />
 		<link rel="stylesheet/less" type="text/css" href="{{ "css/descartes.less" | absURL }}" />
 		<script type="text/javascript" src="{{ "js/less.min.js" | absURL }}"></script>

--- a/static/css/story.less
+++ b/static/css/story.less
@@ -1,5 +1,5 @@
-@font-sans: 'Quattrocento Sans',-apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
-@font-serif: 'Spectral', Georgia, Times, serif;
+@font-sans: '@{config-font-sans}',-apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
+@font-serif: '@{config-font-serif}', Georgia, Times, serif;
 @shaded-bg: #f6f8fa;
 @border: #dfe2e5;
 @muted-text: #6a737d;


### PR DESCRIPTION
Adds support for configurable fonts, as per #82. Only works if you enable `less` in the config.

Sample `config.toml`:

```toml
[params]
    less = true
    [params.fonts.serif]
        family = "Spectral"
        weights = "400,400i,700,700i"
    [params.fonts.sansserif]
        family = "Quattrocento Sans"
        weights = "400,700"
```

*Note* this only touches the default layout, so others, e.g. slides, are still using the preset ones. Changing that, as well, is as easy, though.