### PR TITLE
Switch to internal opengraph

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,8 +12,8 @@
 		{{ with .Keywords }}<meta name="keywords" content="{{.}}">{{ end }}
 		{{ .Hugo.Generator }}
 
-		{{ block "social" . }}
-		{{ end }}
+		{{- template "_internal/opengraph.html" . -}}
+		{{- template "_internal/twitter_cards.html" . -}}
 
 		{{ block "layout" . }}
 		<link rel="stylesheet" href="{{ "css/tachyons.min.css" | absURL }}" />

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,12 +7,6 @@
 {{ end }}
 
 {{ define "social" }}
-		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta property="og:type" content="article" />
-		<meta property="og:image" content="{{ default "img/default-header-img.jpg" .Params.image | absURL }}" />
-		<meta property="og:description" content="{{ .Description | markdownify }}" />
-		<meta property="og:url" content="{{ .Permalink }}" />
-		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
+	{{- template "_internal/opengraph.html" . -}}
+	{{- template "_internal/twitter_cards.html" . -}}
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,8 +5,3 @@
 	{{ .Content }}
 </article>
 {{ end }}
-
-{{ define "social" }}
-	{{- template "_internal/opengraph.html" . -}}
-	{{- template "_internal/twitter_cards.html" . -}}
-{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,8 +16,3 @@
 	</nav>
 </footer>
 {{ end }}
-
-{{ define "social" }}
-	{{- template "_internal/opengraph.html" . -}}
-	{{- template "_internal/twitter_cards.html" . -}}
-{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,12 +18,6 @@
 {{ end }}
 
 {{ define "social" }}
-		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta property="og:type" content="article" />
-		<meta property="og:image" content="{{ default "img/default-header-img.jpg" .Params.image | absURL }}" />
-		<meta property="og:description" content="{{ .Description | markdownify }}" />
-		<meta property="og:url" content="{{ .Permalink }}" />
-		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
+	{{- template "_internal/opengraph.html" . -}}
+	{{- template "_internal/twitter_cards.html" . -}}
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,3 +16,14 @@
 	</nav>
 </footer>
 {{ end }}
+
+{{ define "social" }}
+		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta property="og:type" content="article" />
+		<meta property="og:image" content="{{ default "img/default-header-img.jpg" .Params.image | absURL }}" />
+		<meta property="og:description" content="{{ .Description | markdownify }}" />
+		<meta property="og:url" content="{{ .Permalink }}" />
+		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
+{{ end }}

--- a/layouts/slides/single.html
+++ b/layouts/slides/single.html
@@ -79,12 +79,6 @@
     </script>
 {{ end }}
 
-{{ define "social" }}
-	{{- template "_internal/opengraph.html" . -}}
-	{{- template "_internal/twitter_cards.html" . -}}
-{{ end }}
-
-
 {{ define "about" }}
   <!-- simply override the "header" from baseof.html to make it empty -->
 {{ end }}

--- a/layouts/slides/single.html
+++ b/layouts/slides/single.html
@@ -80,15 +80,10 @@
 {{ end }}
 
 {{ define "social" }}
-		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta property="og:type" content="article" />
-		<meta property="og:image" content="{{ default .Params.image .Params.thumbnail | absURL }}" />
-		<meta property="og:description" content="{{ .Description | markdownify }}" />
-		<meta property="og:url" content="{{ .Permalink }}" />
-		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
+	{{- template "_internal/opengraph.html" . -}}
+	{{- template "_internal/twitter_cards.html" . -}}
 {{ end }}
+
 
 {{ define "about" }}
   <!-- simply override the "header" from baseof.html to make it empty -->

--- a/layouts/talks/single.html
+++ b/layouts/talks/single.html
@@ -62,8 +62,3 @@ $( function() {
 
 </script>
 {{ end }}
-
-{{ define "social" }}
-	{{- template "_internal/opengraph.html" . -}}
-	{{- template "_internal/twitter_cards.html" . -}}
-{{ end }}

--- a/layouts/talks/single.html
+++ b/layouts/talks/single.html
@@ -64,12 +64,6 @@ $( function() {
 {{ end }}
 
 {{ define "social" }}
-		<meta property="og:title" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta property="og:type" content="article" />
-		<meta property="og:image" content="{{ default (default "img/default-header-img.jpg" .Params.image) .Params.thumbnail | absURL }}" />
-		<meta property="og:description" content="{{ .Description | markdownify }}" />
-		<meta property="og:url" content="{{ .Permalink }}" />
-		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
+	{{- template "_internal/opengraph.html" . -}}
+	{{- template "_internal/twitter_cards.html" . -}}
 {{ end }}


### PR DESCRIPTION
Drops the hand-written OGP tags in favour of Hugo's internal templates. This brings the theme closer to Hugo defaults, also making it easier to switch to and from other themes.

Potentially breaking sites built with the previous layout, but fixing it should be easy enough by filling in the proper params https://gohugo.io/templates/internal/#configure-open-graph

I might have missed the reason for having the meta tags like this, but I've made the change on my fork, so I figured I might as well post it here. (Thanks for a great theme, BTW!)