### PR TITLE
Add customizable fonts, fixes #82

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -22,11 +22,11 @@
 		<link rel="stylesheet/less" type="text/css" href="{{ "css/descartes.less" | absURL }}" />
 		<script type="text/javascript" src="{{ "js/less.min.js" | absURL }}"></script>
 		{{ else }}
+		<link rel="stylesheet" href="{{ "css/fonts.css" | relURL }}" />
 		<link rel="stylesheet" href="{{ "css/story.css" | absURL }}" />
 		<link rel="stylesheet" href="{{ "css/descartes.css" | absURL }}" />
 		{{ end }}
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
-		<link href="https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700,700i|Quattrocento:400,700|Spectral:400,400i,700,700i&amp;subset=latin-ext" rel="stylesheet">
 		{{ end }}
 
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>

--- a/layouts/slides/single.html
+++ b/layouts/slides/single.html
@@ -25,7 +25,6 @@
 		}
 		</style>
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
-		<link href="https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700,700i|Quattrocento:400,700|Spectral:400,400i,700,700i&amp;subset=latin-ext" rel="stylesheet">
 {{ end }}
 
 {{ define "header" }}

--- a/static/css/adirondack-fonts.css
+++ b/static/css/adirondack-fonts.css
@@ -1,0 +1,7 @@
+@import url('https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700,700i|Quattrocento:400,700|Spectral:400,400i,700,700i&amp;subset=latin-ext');
+
+:root{
+    --FONT-SANS: 'Quattrocento Sans', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, arial, sans-serif;
+    --FONT-SERIF: Quattrocento, "Goudy Old Style", "Big Caslon", Palatino, serif;
+    --FONT-MONO: Monaco, "Lucida Sans Typewriter", "Lucida Console", "Andale Mono", "Consolas", monospace;
+}

--- a/static/css/adirondack-fonts.less
+++ b/static/css/adirondack-fonts.less
@@ -1,0 +1,5 @@
+@import (css) url('https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700,700i|Quattrocento:400,700|Spectral:400,400i,700,700i&amp;subset=latin-ext');
+
+@font-sans: 'Quattrocento Sans', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, arial, sans-serif;
+@font-serif: Quattrocento, "Goudy Old Style", "Big Caslon", Palatino, serif;
+@font-mono: Monaco, "Lucida Sans Typewriter", "Lucida Console", "Andale Mono", "Consolas", monospace;

--- a/static/css/adirondack.css
+++ b/static/css/adirondack.css
@@ -1,17 +1,19 @@
+@import url('adirondack-fonts.css');
+
 .remark-slide-content {
-  font-family: 'Quattrocento Sans', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, arial, sans-serif;
+  font-family: var(--FONT-SANS);
 }
 .remark-slide-content pre,
 .remark-slide-content code,
 .remark-slide-content kbd,
 .remark-slide-content tt,
 .remark-slide-content samp {
-  font-family: Monaco, "Lucida Sans Typewriter", "Lucida Console", "Andale Mono", "Consolas", monospace;
+  font-family: var(--FONT-MONO);
 }
 .remark-slide-content h1,
 .remark-slide-content h2,
 .remark-slide-content h3 {
-  font-family: Quattrocento, "Goudy Old Style", "Big Caslon", Palatino, serif;
+  font-family: var(--FONT-SERIF);
   font-weight: bold;
 }
 .remark-slide-content table {

--- a/static/css/adirondack.less
+++ b/static/css/adirondack.less
@@ -1,3 +1,5 @@
+@import "adirondack-fonts.less";
+
 @adirondack-colors: {
 	muted-text: #6a737d;
 	shaded-bg: #f6f8fa;
@@ -5,15 +7,12 @@
 }
 
 .remark-slide-content {
-	font-family: 'Quattrocento Sans',-apple-system, BlinkMacSystemFont,
-		'avenir next', avenir, 'helvetica neue', helvetica,
-		arial, sans-serif;
+	font-family: @font-sans;
 	pre, code, kbd, tt, samp {
-		font-family: Monaco, "Lucida Sans Typewriter", "Lucida Console",
-			"Andale Mono", "Consolas", monospace;
+		font-family: @font-mono;
 	}
 	h1, h2, h3 {
-		font-family: Quattrocento, "Goudy Old Style", "Big Caslon", Palatino, serif;
+		font-family: @font-serif;
 		font-weight: bold;
 	}
 

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -1,0 +1,6 @@
+@import url('https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700,700i|Spectral:400,400i,700,700i&subset=latin-ext');
+
+:root{
+    --FONT-SANS: 'Quattrocento Sans', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
+    --FONT-SERIF: 'Spectral', Georgia, Times, serif;
+}

--- a/static/css/fonts.less
+++ b/static/css/fonts.less
@@ -1,0 +1,4 @@
+@import (css) url('https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700,700i|Spectral:400,400i,700,700i&subset=latin-ext');
+
+@font-sans: 'Quattrocento Sans',-apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
+@font-serif: 'Spectral', Georgia, Times, serif;

--- a/static/css/story.css
+++ b/static/css/story.css
@@ -3,15 +3,15 @@ h2,
 h3,
 h4,
 .sans-serif {
-  font-family: 'Quattrocento Sans', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
+  font-family: var(--FONT-SANS);
 }
 body article {
-  font-family: 'Spectral', Georgia, Times, serif;
+  font-family: var(--FONT-SERIF);
 }
 @media only screen and (max-width: 30em) {
   body article p,
   body article li {
-    font-family: 'Quattrocento Sans', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
+    font-family: var(--FONT-SANS);
   }
 }
 @media only screen and (min-width: 50em) {
@@ -61,7 +61,7 @@ hr {
 }
 table caption {
   text-align: left;
-  font-family: 'Spectral', Georgia, Times, serif;
+  font-family: var(--FONT-SERIF);
   font-style: italic;
   padding: 0px 0.5rem;
 }
@@ -141,7 +141,7 @@ body:not(.feature-tablefig) table {
   width: 100%;
   overflow: auto;
   font-size: 85%;
-  font-family: 'Quattrocento Sans', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
+  font-family: var(--FONT-SERIF);
 }
 body:not(.feature-tablefig) table tr:nth-child(2n) {
   background-color: #f6f8fa;

--- a/static/css/story.less
+++ b/static/css/story.less
@@ -1,5 +1,5 @@
-@font-sans: 'Quattrocento Sans',-apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
-@font-serif: 'Spectral', Georgia, Times, serif;
+@import "fonts.less";
+
 @shaded-bg: #f6f8fa;
 @border: #dfe2e5;
 @muted-text: #6a737d;


### PR DESCRIPTION
OK, long overdue, but here is my attempt at addressing #82. I've split the fonts definition into a separate css/less file. This allows the theme user to override this specific style file (fonts.css or fonts.less) by placing a copy into MYSITE/static/css and changing the file to include and use different fonts.

Supports both css and less styles. The CSS is achieved thru usage of CSS variables. According to https://caniuse.com/#feat=css-variables it is supported by 93% of global users. Less is easy, most of the work was already done there, I just split the fonts definition out.

As part of this PR, I also removed the Quattrocento font from the Google fonts package, because it is not used anywhere on the pages. It is used in slides, but that has a different CSS altogether. ~~I did not touch that one (adirondack.css/.less).~~ (EDIT: See next commit)

Let me know what you think and thank you so much for your work on Story, it is a great theme and I use it for my personal website.

If you think this is a good way, I will update the documentation. I'd put it in https://story.xaprb.com/typography/, maybe? 