### PR TITLE
Add option to render tags

### DIFF
--- a/exampleSite/content/features.md
+++ b/exampleSite/content/features.md
@@ -7,8 +7,12 @@ credit: "https://unsplash.com/photos/QRkew0KwXSM"
 image: "img/unsplash-photos-QRkew0KwXSM.jpg"
 thumbnail: img/unsplash-photos-QRkew0KwXSM.tn-500x500.jpg
 classes:
+- feature-rendertags
 categories:
 - Demo
+tags:
+- demo
+- features
 ---
 Feature flags, which are called _classes_ in the markup, control many of Story's features.
 You can enable and disable them in your site config, or in an individual post's front matter.
@@ -105,5 +109,6 @@ For brevity, the `feature-` prefix is omitted, but all of Story's classes have t
 | [tablefw](/figures)            | Sets table cells in a font with fixed-width numerals                                        | CSS            |
 | titlecase                      | Not enabled by default; Transforms All Content Titles to Titlecase                          | Hugo           |
 | [tweetquote](/typography)      | Renders a blockquote in a simplistic tweet style, if it follows conventions                 | JS + CSS       |
+| rendertags                     | Renders a clickable list of tags at the bottom of the article (see below)                   | Hugo           |
 
 Read next: [Story's author biographies](/author-profiles/).

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,6 +3,11 @@
 {{ define "main" }}
 <article class="center bg-white br-3 pv1 ph4 lh-copy f5 nested-links mw7">
 	{{ .Content }}
+	{{- if or (in .Site.Params.classes "feature-rendertags") (in .Params.classes "feature-rendertags") -}}
+		{{- if not (or (in .Site.Params.classes "feature-norendertags") (in .Params.classes "feature-norendertags") ) -}}
+			{{ block "tags" . }}{{ end }}
+		{{- end -}}
+	{{- end -}}
 </article>
 {{ end }}
 
@@ -15,4 +20,19 @@
 		<meta property="og:site_name" content="{{ cond (eq .Site.Params.titlecase true) (.Title | title | markdownify) (.Title | markdownify) }}" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
+{{ end }}
+
+{{ define "tags" }}
+	{{ $taxo := "tags" -}}
+	{{- with .Param $taxo -}}
+	<div>
+		<strong>Tag{{ if gt (len .) 1 }}s{{ end }}:</strong>
+		{{ range $index, $tag := . }}
+		{{- if gt $index 0 }}, {{ end -}}
+		{{- with $.Site.GetPage (printf "/%s/%s" $taxo $tag) -}}
+		<a href="{{ .Permalink }}">{{ $tag }}</a>
+		{{- end -}}
+		{{- end -}}
+	</div>
+	{{- end }}
 {{ end }}


### PR DESCRIPTION
I am using tags on my site and wanted a simple way to render them into the article. I have added the option to enable/disable this feature in the same way as other feature toggles work. The name of the option is `feature-rendertags` and `feature-norendertags` and can be set in global site config or article front matter.

Default is it's off, so it should be safe to merge. I have changed the docs too and added a demo of the feature into the `/features/` page.

Thanks for considering merging this. If you feel it needs some change, let me know.