### PR TITLE
Use hugo fn instead of deprecated .Page.Hugo

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
 		<link rel="shortcut icon" type="image/png" href="{{ "apple-touch-icon-precomposed.png" | absURL }}">
 		{{ with .Description }}<meta name="description" content="{{. | markdownify }}">{{ end }}
 		{{ with .Keywords }}<meta name="keywords" content="{{.}}">{{ end }}
-		{{ .Hugo.Generator }}
+		{{ hugo.Generator }}
 
 		{{ block "social" . }}
 		{{ end }}


### PR DESCRIPTION
Recent versions of Hugo started complaining about usage of deprecated Page.Hugo. 

```
WARN 2019/12/29 16:05:09 Page.Hugo is deprecated and will be removed in a future release. Use the global hugo function.
```

According to https://gohugo.io/variables/hugo/ one should use `hugo` global function. This PR does that.