### PR TITLE
Fix for: failed to extract shortcode: template for shortcode "math" n…

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,7 @@ baseurl = "https://example.com/"
 title = "Hugo Story Theme"
 paginate = 5
 buildFuture = true
+theme = "story"
 
 [[menu.social]]
   name = "GitHub"


### PR DESCRIPTION
When using OOTB, the following error is shown:
```
Error: Error building site: "./test-story-theme/themes/story/exampleSite/content/math.md:19:26": failed to extract shortcode: template for shortcode "math" not found
```

## Steps to reproduce:

1. Generate empty site and add story theme as submodule

```
hugo new site test-story-theme
git init . 
git add .
git commit -m "New site to debug Story theme"
git submodule add git@github.com:miroadamy/story.git themes/story
git commit -m "Added submodule - themes/story"

hugo server -D  --themesDir ../..
Built in 35 ms
Error: Error building site: "/Users/miro/prj/w-clar-technical-blog/src/test-story-theme/themes/story/exampleSite/content/math.md:19:26": failed to extract shortcode: template for shortcode "math" not found
```

The error is caused by missing theme directive in config.

After adding it, it works.

```
git diff
diff --git a/exampleSite/config.toml b/exampleSite/config.toml
index 47cdf2b..75b1f20 100644
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,7 @@ baseurl = "https://example.com/"
 title = "Hugo Story Theme"
 paginate = 5
 buildFuture = true
+theme = "story"

 [[menu.social]]
   name = "GitHub"

hugo server -D  --themesDir ../..
Building sites … WARN 2020/04/22 16:01:19 Page.Hugo is deprecated and will be removed in a future release. Use the global hugo function.

                   | EN
-------------------+------
  Pages            |  38
  Paginator pages  |   4
  Non-page files   |  41
  Static files     | 424
  Processed images |   0
  Aliases          |   8
  Sitemaps         |   1
  Cleaned          |   0

Built in 150 ms
Watching for changes in /Users/miro/prj/w-clar-technical-blog/src/test-story-theme/themes/story/{archetypes,exampleSite,layouts,static}
Watching for config changes in /Users/miro/prj/w-clar-technical-blog/src/test-story-theme/themes/story/exampleSite/config.toml
Environment: "development"
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop
^C%
```